### PR TITLE
refactor: remove legacy shared webhook secret path

### DIFF
--- a/docs/webhooks-and-secrets.md
+++ b/docs/webhooks-and-secrets.md
@@ -1,42 +1,32 @@
 # Webhooks and Secrets
 
+Each GitHub organization (a "client") has its own webhook secret and posts to a dedicated
+endpoint: `POST /webhook/{clientId}`, where `clientId` is the GitHub organization name
+(e.g. `capralifecycle`). Secrets are stored in AWS Secrets Manager and injected via the
+infrastructure stack.
+
 When configuring a Webhook in GitHub, you select:
 
-- **Payload URL**: `https://ci-dashboard.liflig.io/webhook`
+- **Payload URL**: `https://ci-dashboard.liflig.io/webhook/<org-name>`
 - **Content type**: `application/json`
 - **Secret**: `a long and high entropy random string`
 - **Events**: `workflow_run`
 - **Active**: `true`
 
-The **Secret** should be kept in e.g. a Password manager (ours is in 1Password
-in `liflig-team-infra/GitHub Actions CI Dashboard Webhook Secret`).
-The secret should be set via the infrastructure
-and [liflig-properties](https://github.com/capralifecycle/liflig-properties) as `webhook.secret` (we did
-it [here](https://github.com/capralifecycle/liflig-experiments-infra/blob/2103c2b276fe54f0ce74c55d70e139c486dd16f3/load-secrets-github-actions-ci-dashboard.ts#L5)).
-This overwrites the sample value in `application.properties` during runtime.
-
 ## GitHub and Signing Webhook POST Requests
 
-Every Webhook POST request from GitHub will sign its request Body with this **Secret** and HMAC SHA256,
+Every Webhook POST request from GitHub will sign its request Body with the **Secret** and HMAC SHA256,
 and send the signature as a HTTP Header `X-Hub-Signature-256`.
 The value of the header is `sha256=<lowercase-hex-digest>`, like:
 
 ```http request
-POST /webhook
+POST /webhook/<org-name>
 X-Hub-Signature-256: sha256=5c5134a624883d7df34eae110bf37f78a0620b159fd884760c40a66a3903293f
 
 { "requestBody": "goes here" }
 ```
 
-## Per-client secrets (recommended)
-
-Instead of a single shared secret, each GitHub organization can have its own webhook secret
-via a dedicated endpoint: `POST /webhook/{clientId}`.
-
-The `clientId` is the GitHub organization name (e.g. `capralifecycle`). Each client has its
-own secret stored in AWS Secrets Manager.
-
-### Adding a new client
+## Adding a new client
 
 1. Generate a secret: `openssl rand -base64 32`
 2. Add the secret to `load-secrets-github-actions-ci-dashboard.ts` in liflig-experiments-infra
@@ -46,7 +36,7 @@ own secret stored in AWS Secrets Manager.
 5. Deploy the dashboard
 6. Configure the GitHub webhook URL to `https://ci-dashboard.liflig.io/webhook/<org-name>`
 
-### Rotating a per-client secret
+## Rotating a per-client secret
 
 1. Generate a new secret
 2. Update it in AWS Secrets Manager (via the load-secrets script)
@@ -54,29 +44,7 @@ own secret stored in AWS Secrets Manager.
 4. Update the secret in the GitHub organization webhook config
 5. Done
 
-## Rotating the legacy shared secret
-
-> **Note:** This applies to the legacy `/webhook` endpoint. Prefer migrating to per-client
-> secrets above.
-
-This process will result in approximately 10 minutes of downtime for github-actions-ci-dashboards.
-
-### When to Use
-If the GitHub signing secret is compromised, it is necessary to rotate the secret. All GitHub organizations and repositories using this secret must be updated simultaneously, as this project does not support staggered secret updates (expand and contract).
-Generate a New Secret: Use a reliable password manager or tool to generate a 32-character random password.
-
-1. Update in 1Password: Save the new secret in 1Password under liflig-team-infra/GitHub Actions CI Dashboard Webhook Secret.
-2. Notify the Team: Inform #dev-utvikling at least 30 minutes before rotating the secret. Use a message template like:
-   1. "The GitHub Actions CI Dashboard Webhook Secret will be rotated at [time]. Downtime is expected for approximately 10 minutes. The new secret is available in 1Password under liflig-team-infra/GitHub Actions CI Dashboard Webhook Secret."
-3. Update the Secret trough CLI: Run the load-secrets-script in the liflig-experiments repository to update the secret.
-4. Update the secret in capralifecycle organization (you will need admin access)
-5. Redeploy: Force a new deployment of liflig-ci-dashboards.
-6. Validate and Notify: Confirm that GitHub Actions are reporting correctly. Notify #dev-utvikling that the rotation was successful.
-
-
 ## References
 
 - [HMAC signature header (GitHub Docs)](https://docs.github.com/en/webhooks/webhook-events-and-payloads#delivery-headers)
 - [Validating webhook deliveries (GitHub Docs)](https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries)
-
-

--- a/src/main/kotlin/no/liflig/cidashboard/Api.kt
+++ b/src/main/kotlin/no/liflig/cidashboard/Api.kt
@@ -73,9 +73,6 @@ fun createApiServer(
                   options.clientSecretToken,
                   options.hotReloadTemplates,
               ),
-          webhookOptions.path bind
-              Method.POST to
-              WebhookSecretValidatorFilter(webhookOptions.secret).then(webhookEndpoint),
           "${webhookOptions.path}/{clientId}" bind
               Method.POST to
               WebhookSecretValidatorFilter { request ->

--- a/src/main/kotlin/no/liflig/cidashboard/common/config/WebhookOptions.kt
+++ b/src/main/kotlin/no/liflig/cidashboard/common/config/WebhookOptions.kt
@@ -9,13 +9,12 @@ import no.liflig.properties.stringNotEmpty
 data class WebhookOptions(
     /** Full path to webhook. Must start with `/`. */
     val path: String,
-    val secret: Secret,
     /**
      * Per-client webhook secrets, keyed by client ID (e.g. GitHub organization name like
      * "capralifecycle"). Each client can have its own secret, allowing independent secret rotation
      * without downtime.
      *
-     * Clients POST to `/webhook/{clientId}` instead of `/webhook`.
+     * Clients POST to `/webhook/{clientId}`.
      *
      * See `/docs/webhooks-and-secrets.md`.
      */
@@ -52,7 +51,6 @@ data class WebhookOptions(
     fun from(properties: Properties): WebhookOptions =
         WebhookOptions(
             path = properties.stringNotEmpty("webhook.path"),
-            secret = Secret(properties.stringNotEmpty("webhook.secret")),
             clientSecrets = clientSecretsFrom(properties),
             branchWhitelist =
                 properties

--- a/src/main/kotlin/no/liflig/cidashboard/webhook/WebhookSecretValidatorFilter.kt
+++ b/src/main/kotlin/no/liflig/cidashboard/webhook/WebhookSecretValidatorFilter.kt
@@ -18,17 +18,15 @@ import org.http4k.security.HmacSha256
  * Prevents unsigned webhook requests with a 401 Unauthorized. GitHub will always sign its POST
  * requests with a secret and a header.
  *
- * Accepts a [secretResolver] function to support both the shared webhook secret (legacy) and
- * per-client secrets. If the resolver returns null (unknown client), responds with 404.
+ * The [secretResolver] looks up the per-client secret from the incoming [Request] (typically by
+ * extracting the `clientId` path parameter). If the resolver returns null (unknown client),
+ * responds with 404.
  *
  * See `/docs/webhooks-and-secrets.md`.
  */
 class WebhookSecretValidatorFilter(
     private val secretResolver: (Request) -> WebhookOptions.Secret?,
 ) : Filter {
-
-  /** Convenience constructor for a single shared secret (legacy endpoint). */
-  constructor(secret: WebhookOptions.Secret) : this({ secret })
 
   companion object {
     private val log = getLogger()

--- a/src/main/resources-filtered/application.properties
+++ b/src/main/resources-filtered/application.properties
@@ -17,7 +17,6 @@ api.devtool.secret=change-me-to-something-secret
 
 # Webhook
 webhook.path=/webhook
-webhook.secret=sample
 webhook.branchWhitelist=master,main,production
 webhook.workflowNameWhitelist=ci
 

--- a/src/test/kotlin/acceptancetests/CiDashboardTest.kt
+++ b/src/test/kotlin/acceptancetests/CiDashboardTest.kt
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.extension.RegisterExtension
 import test.util.AcceptanceTestExtension
 import test.util.FileWebhookPayload
 import test.util.Integration
+import test.util.TestConstants.TEST_CLIENT_ID
+import test.util.TestConstants.TEST_CLIENT_SECRET
 
 @Integration
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -18,7 +20,12 @@ import test.util.Integration
 class CiDashboardTest {
 
   companion object {
-    @JvmField @RegisterExtension val infra = AcceptanceTestExtension()
+    @JvmField
+    @RegisterExtension
+    val infra =
+        AcceptanceTestExtension(
+            clientSecrets = mapOf(TEST_CLIENT_ID to TEST_CLIENT_SECRET),
+        )
   }
 
   @Test
@@ -26,20 +33,32 @@ class CiDashboardTest {
     infra.tvBrowser.navigateToDashboard()
     infra.tvBrowser.verifyDashboardIsEmpty()
 
-    infra.gitHub.sendWebhook(FileWebhookPayload.ExampleRepo.WORKFLOW_RUN_1_REQUESTED)
+    infra.gitHub.sendWebhook(
+        FileWebhookPayload.ExampleRepo.WORKFLOW_RUN_1_REQUESTED,
+        TEST_CLIENT_ID,
+    )
     infra.tvBrowser.verifyDashboardHasRepoInStatus(FileWebhookPayload.ExampleRepo.repoName, QUEUED)
 
-    infra.gitHub.sendWebhook(FileWebhookPayload.ExampleRepo.WORKFLOW_RUN_1_IN_PROGRESS)
+    infra.gitHub.sendWebhook(
+        FileWebhookPayload.ExampleRepo.WORKFLOW_RUN_1_IN_PROGRESS,
+        TEST_CLIENT_ID,
+    )
     infra.tvBrowser.verifyDashboardHasRepoInStatus(
         FileWebhookPayload.ExampleRepo.repoName,
         IN_PROGRESS,
     )
 
-    infra.gitHub.sendWebhook(FileWebhookPayload.ExampleRepo.WORKFLOW_RUN_1_COMPLETED_FAILURE)
+    infra.gitHub.sendWebhook(
+        FileWebhookPayload.ExampleRepo.WORKFLOW_RUN_1_COMPLETED_FAILURE,
+        TEST_CLIENT_ID,
+    )
     infra.tvBrowser.verifyDashboardHasRepoInStatus(FileWebhookPayload.ExampleRepo.repoName, FAILED)
     infra.tvBrowser.verifyAllFailedBuildsIsListingRepo(FileWebhookPayload.ExampleRepo.repoName)
 
-    infra.gitHub.sendWebhook(FileWebhookPayload.ExampleRepo.WORKFLOW_RUN_1_COMPLETED_SUCCESS)
+    infra.gitHub.sendWebhook(
+        FileWebhookPayload.ExampleRepo.WORKFLOW_RUN_1_COMPLETED_SUCCESS,
+        TEST_CLIENT_ID,
+    )
     infra.tvBrowser.verifyDashboardHasRepoInStatus(
         FileWebhookPayload.ExampleRepo.repoName,
         SUCCEEDED,
@@ -47,13 +66,15 @@ class CiDashboardTest {
 
     // Create a screenshot for Readme with some more data.
     infra.gitHub.sendWebhook(
-        FileWebhookPayload.DataForScreenshots.LIFLIG_PROPERTIES_WORKFLOW_RUN_1_COMPLETED_FAILURE
+        FileWebhookPayload.DataForScreenshots.LIFLIG_PROPERTIES_WORKFLOW_RUN_1_COMPLETED_FAILURE,
+        TEST_CLIENT_ID,
     )
     infra.tvBrowser.verifyAllFailedBuildsIsListingRepo(
         FileWebhookPayload.DataForScreenshots.repoNameLifligProperties
     )
     infra.gitHub.sendWebhook(
-        FileWebhookPayload.DataForScreenshots.LIFLIG_CDK_WORKFLOW_RUN_2_IN_PROGRESS
+        FileWebhookPayload.DataForScreenshots.LIFLIG_CDK_WORKFLOW_RUN_2_IN_PROGRESS,
+        TEST_CLIENT_ID,
     )
     infra.tvBrowser.verifyDashboardHasRepoInStatus(
         FileWebhookPayload.DataForScreenshots.repoNameLifligCdk,

--- a/src/test/kotlin/acceptancetests/DevelopmentAid.kt
+++ b/src/test/kotlin/acceptancetests/DevelopmentAid.kt
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.RegisterExtension
 import test.util.AcceptanceTestExtension
 import test.util.Integration
+import test.util.TestConstants.TEST_CLIENT_ID
+import test.util.TestConstants.TEST_CLIENT_SECRET
 import test.util.WebhookPayload
 import test.util.loadResource
 
@@ -20,7 +22,13 @@ import test.util.loadResource
 class DevelopmentAid {
 
   companion object {
-    @JvmField @RegisterExtension val infra = AcceptanceTestExtension(fastPoll = false)
+    @JvmField
+    @RegisterExtension
+    val infra =
+        AcceptanceTestExtension(
+            fastPoll = false,
+            clientSecrets = mapOf(TEST_CLIENT_ID to TEST_CLIENT_SECRET),
+        )
   }
 
   @Test
@@ -31,24 +39,46 @@ class DevelopmentAid {
     val testWithManyRepos = true
     if (testWithManyRepos) {
       repeat(40) {
-        infra.gitHub.sendWebhook(createPayload("repo-x$it", CiStatus.PipelineStatus.SUCCEEDED))
+        infra.gitHub.sendWebhook(
+            createPayload("repo-x$it", CiStatus.PipelineStatus.SUCCEEDED),
+            TEST_CLIENT_ID,
+        )
       }
       repeat(5) {
-        infra.gitHub.sendWebhook(createPayload("repo-y$it", CiStatus.PipelineStatus.FAILED))
+        infra.gitHub.sendWebhook(
+            createPayload("repo-y$it", CiStatus.PipelineStatus.FAILED),
+            TEST_CLIENT_ID,
+        )
       }
     }
 
-    infra.gitHub.sendWebhook(createPayload("repo-c", CiStatus.PipelineStatus.SUCCEEDED))
-    infra.gitHub.sendWebhook(createPayload("repo-d", CiStatus.PipelineStatus.FAILED))
-    infra.gitHub.sendWebhook(createPayload("repo-e", CiStatus.PipelineStatus.CANCELLED))
-
-    // Give it a previous success runtime, to measure progress
-    infra.gitHub.sendWebhook(createPayload("repo-b", CiStatus.PipelineStatus.SUCCEEDED))
     infra.gitHub.sendWebhook(
-        createPayload("repo-b", CiStatus.PipelineStatus.IN_PROGRESS, startedAt = Instant.now())
+        createPayload("repo-c", CiStatus.PipelineStatus.SUCCEEDED),
+        TEST_CLIENT_ID,
+    )
+    infra.gitHub.sendWebhook(
+        createPayload("repo-d", CiStatus.PipelineStatus.FAILED),
+        TEST_CLIENT_ID,
+    )
+    infra.gitHub.sendWebhook(
+        createPayload("repo-e", CiStatus.PipelineStatus.CANCELLED),
+        TEST_CLIENT_ID,
     )
 
-    infra.gitHub.sendWebhook(createPayload("repo-a", CiStatus.PipelineStatus.QUEUED))
+    // Give it a previous success runtime, to measure progress
+    infra.gitHub.sendWebhook(
+        createPayload("repo-b", CiStatus.PipelineStatus.SUCCEEDED),
+        TEST_CLIENT_ID,
+    )
+    infra.gitHub.sendWebhook(
+        createPayload("repo-b", CiStatus.PipelineStatus.IN_PROGRESS, startedAt = Instant.now()),
+        TEST_CLIENT_ID,
+    )
+
+    infra.gitHub.sendWebhook(
+        createPayload("repo-a", CiStatus.PipelineStatus.QUEUED),
+        TEST_CLIENT_ID,
+    )
 
     println(
         "\n".repeat(10) +

--- a/src/test/kotlin/acceptancetests/PerClientWebhookTest.kt
+++ b/src/test/kotlin/acceptancetests/PerClientWebhookTest.kt
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.extension.RegisterExtension
 import test.util.AcceptanceTestExtension
 import test.util.FileWebhookPayload
 import test.util.Integration
+import test.util.TestConstants.TEST_CLIENT_ID
+import test.util.TestConstants.TEST_CLIENT_SECRET
 
 @Integration
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -15,9 +17,6 @@ import test.util.Integration
 class PerClientWebhookTest {
 
   companion object {
-    const val TEST_CLIENT_ID = "test-org"
-    const val TEST_CLIENT_SECRET = "test-client-secret"
-
     @JvmField
     @RegisterExtension
     val infra =
@@ -27,11 +26,11 @@ class PerClientWebhookTest {
   }
 
   @Test
-  fun `should accept webhook via per-client endpoint`() {
+  fun `webhook is accepted and status becomes visible`() {
     infra.tvBrowser.navigateToDashboard()
     infra.tvBrowser.verifyDashboardIsEmpty()
 
-    infra.gitHub.sendWebhookWithClientId(
+    infra.gitHub.sendWebhook(
         FileWebhookPayload.ExampleRepo.WORKFLOW_RUN_1_REQUESTED,
         TEST_CLIENT_ID,
     )

--- a/src/test/kotlin/no/liflig/cidashboard/webhook/WebhookSecretValidatorFilterTest.kt
+++ b/src/test/kotlin/no/liflig/cidashboard/webhook/WebhookSecretValidatorFilterTest.kt
@@ -3,19 +3,19 @@ package no.liflig.cidashboard.webhook
 import java.util.concurrent.atomic.AtomicBoolean
 import no.liflig.cidashboard.common.config.WebhookOptions
 import org.assertj.core.api.Assertions.assertThat
-import org.http4k.core.Headers
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.security.HmacSha256
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class WebhookSecretValidatorFilterTest {
 
-  private val secret = WebhookOptions.Secret("It's a Secret to Everybody")
+  private val clientId = "test-org"
+  private val clientSecret = WebhookOptions.Secret("client-specific-secret")
+  private val clientSecrets = mapOf(clientId to clientSecret)
 
   private fun nextHandlerSpy(): Pair<AtomicBoolean, HttpHandler> {
     val called = AtomicBoolean(false)
@@ -32,120 +32,82 @@ class WebhookSecretValidatorFilterTest {
           HmacSha256.hmacSHA256(secret.value.toByteArray(Charsets.UTF_8), body)
               .toHexString(HexFormat.Default)
 
-  @Nested
-  inner class SharedSecret {
-    @Test
-    fun `should validate secret using sha-256`() {
-      val (nextHandlerWasCalled, okHandler) = nextHandlerSpy()
-      val body = "Hello, World!"
-      val request =
-          Request(Method.POST, "/webhook")
-              .body(body)
-              .header("X-Hub-Signature-256", sign(body, secret))
-
-      val response = WebhookSecretValidatorFilter(secret).invoke(okHandler).invoke(request)
-
-      assertThat(nextHandlerWasCalled).`as`("Next handler was not invoked").isTrue()
-      assertThat(response.status).isEqualTo(Status.OK)
-    }
-
-    @Test
-    fun `should stop execution of request with invalid signature`() {
-      val (nextHandlerWasCalled, okHandler) = nextHandlerSpy()
-      val headers: Headers =
-          listOf(
-              "X-Hub-Signature-256" to
-                  "sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-          )
-      val request = Request(Method.POST, "/webhook").body("Hello, World!").replaceHeaders(headers)
-
-      val response = WebhookSecretValidatorFilter(secret).invoke(okHandler).invoke(request)
-
-      assertThat(nextHandlerWasCalled).`as`("Next handler was invoked").isFalse()
-      assertThat(response.status).isEqualTo(Status.UNAUTHORIZED)
-    }
-
-    @Test
-    fun `should stop execution of request with missing signature`() {
-      val (nextHandlerWasCalled, okHandler) = nextHandlerSpy()
-      val request = Request(Method.POST, "/webhook").body("Hello, World!")
-
-      val response = WebhookSecretValidatorFilter(secret).invoke(okHandler).invoke(request)
-
-      assertThat(nextHandlerWasCalled).`as`("Next handler was invoked").isFalse()
-      assertThat(response.status).isEqualTo(Status.UNAUTHORIZED)
-    }
+  // In production, the clientId is extracted via a Path lens.
+  // In these unit tests we pass it as a query parameter for simplicity.
+  private fun resolverFromMap(
+      secrets: Map<String, WebhookOptions.Secret>
+  ): (Request) -> WebhookOptions.Secret? = { request ->
+    val id = request.query("clientId")
+    id?.let { secrets[it] }
   }
 
-  @Nested
-  inner class PerClientSecret {
-    private val clientId = "test-org"
-    private val clientSecret = WebhookOptions.Secret("client-specific-secret")
-    private val clientSecrets = mapOf(clientId to clientSecret)
+  @Test
+  fun `should validate with correct per-client secret`() {
+    val (nextHandlerWasCalled, okHandler) = nextHandlerSpy()
+    val body = "Hello, World!"
+    val request =
+        Request(Method.POST, "/webhook?clientId=$clientId")
+            .body(body)
+            .header("X-Hub-Signature-256", sign(body, clientSecret))
 
-    private fun resolverFromMap(
-        secrets: Map<String, WebhookOptions.Secret>
-    ): (Request) -> WebhookOptions.Secret? = { request ->
-      // In production, the clientId is extracted via a Path lens.
-      // In these unit tests we pass it as a query parameter for simplicity.
-      val id = request.query("clientId")
-      id?.let { secrets[it] }
-    }
+    val response =
+        WebhookSecretValidatorFilter(resolverFromMap(clientSecrets))
+            .invoke(okHandler)
+            .invoke(request)
 
-    @Test
-    fun `should validate with correct per-client secret`() {
-      val (nextHandlerWasCalled, okHandler) = nextHandlerSpy()
-      val body = "Hello, World!"
-      val request =
-          Request(Method.POST, "/webhook?clientId=$clientId")
-              .body(body)
-              .header("X-Hub-Signature-256", sign(body, clientSecret))
+    assertThat(nextHandlerWasCalled).`as`("Next handler was not invoked").isTrue()
+    assertThat(response.status).isEqualTo(Status.OK)
+  }
 
-      val response =
-          WebhookSecretValidatorFilter(resolverFromMap(clientSecrets))
-              .invoke(okHandler)
-              .invoke(request)
+  @Test
+  fun `should reject request signed with wrong client secret`() {
+    val (nextHandlerWasCalled, okHandler) = nextHandlerSpy()
+    val wrongSecret = WebhookOptions.Secret("wrong-secret")
+    val body = "Hello, World!"
+    val request =
+        Request(Method.POST, "/webhook?clientId=$clientId")
+            .body(body)
+            .header("X-Hub-Signature-256", sign(body, wrongSecret))
 
-      assertThat(nextHandlerWasCalled).`as`("Next handler was not invoked").isTrue()
-      assertThat(response.status).isEqualTo(Status.OK)
-    }
+    val response =
+        WebhookSecretValidatorFilter(resolverFromMap(clientSecrets))
+            .invoke(okHandler)
+            .invoke(request)
 
-    @Test
-    fun `should reject request signed with wrong client secret`() {
-      val (nextHandlerWasCalled, okHandler) = nextHandlerSpy()
-      val wrongSecret = WebhookOptions.Secret("wrong-secret")
-      val body = "Hello, World!"
-      val request =
-          Request(Method.POST, "/webhook?clientId=$clientId")
-              .body(body)
-              .header("X-Hub-Signature-256", sign(body, wrongSecret))
+    assertThat(nextHandlerWasCalled).`as`("Next handler was invoked").isFalse()
+    assertThat(response.status).isEqualTo(Status.UNAUTHORIZED)
+  }
 
-      val response =
-          WebhookSecretValidatorFilter(resolverFromMap(clientSecrets))
-              .invoke(okHandler)
-              .invoke(request)
+  @Test
+  fun `should reject request with missing signature header`() {
+    val (nextHandlerWasCalled, okHandler) = nextHandlerSpy()
+    val request = Request(Method.POST, "/webhook?clientId=$clientId").body("Hello, World!")
 
-      assertThat(nextHandlerWasCalled).`as`("Next handler was invoked").isFalse()
-      assertThat(response.status).isEqualTo(Status.UNAUTHORIZED)
-    }
+    val response =
+        WebhookSecretValidatorFilter(resolverFromMap(clientSecrets))
+            .invoke(okHandler)
+            .invoke(request)
 
-    @Test
-    fun `should return 404 for unknown client id`() {
-      val (nextHandlerWasCalled, okHandler) = nextHandlerSpy()
-      val body = "Hello, World!"
-      val unknownClientId = "unknown-org"
-      val request =
-          Request(Method.POST, "/webhook?clientId=$unknownClientId")
-              .body(body)
-              .header("X-Hub-Signature-256", sign(body, clientSecret))
+    assertThat(nextHandlerWasCalled).`as`("Next handler was invoked").isFalse()
+    assertThat(response.status).isEqualTo(Status.UNAUTHORIZED)
+  }
 
-      val response =
-          WebhookSecretValidatorFilter(resolverFromMap(clientSecrets))
-              .invoke(okHandler)
-              .invoke(request)
+  @Test
+  fun `should return 404 for unknown client id`() {
+    val (nextHandlerWasCalled, okHandler) = nextHandlerSpy()
+    val body = "Hello, World!"
+    val unknownClientId = "unknown-org"
+    val request =
+        Request(Method.POST, "/webhook?clientId=$unknownClientId")
+            .body(body)
+            .header("X-Hub-Signature-256", sign(body, clientSecret))
 
-      assertThat(nextHandlerWasCalled).`as`("Next handler was invoked").isFalse()
-      assertThat(response.status).isEqualTo(Status.NOT_FOUND)
-    }
+    val response =
+        WebhookSecretValidatorFilter(resolverFromMap(clientSecrets))
+            .invoke(okHandler)
+            .invoke(request)
+
+    assertThat(nextHandlerWasCalled).`as`("Next handler was invoked").isFalse()
+    assertThat(response.status).isEqualTo(Status.NOT_FOUND)
   }
 }

--- a/src/test/kotlin/test/util/AcceptanceTestExtension.kt
+++ b/src/test/kotlin/test/util/AcceptanceTestExtension.kt
@@ -75,7 +75,6 @@ class AcceptanceTestExtension(
     gitHub.initialize(
         port = config.apiOptions.serverPort,
         webhookPath = config.webhookOptions.path,
-        webhookSecret = config.webhookOptions.secret,
         clientSecrets = config.webhookOptions.clientSecrets,
     )
 
@@ -119,7 +118,6 @@ class AcceptanceTestExtension(
 
     private var webhookDestinationPort: Port = Port(8080)
     private lateinit var webhookPath: String
-    private var webhookSecret: WebhookOptions.Secret = WebhookOptions.Secret("unknown")
     private var clientSecrets: Map<String, WebhookOptions.Secret> = emptyMap()
 
     private lateinit var webhookPostRequest: RequestSpecification
@@ -127,12 +125,10 @@ class AcceptanceTestExtension(
     fun initialize(
         port: Port,
         webhookPath: String,
-        webhookSecret: WebhookOptions.Secret,
         clientSecrets: Map<String, WebhookOptions.Secret> = emptyMap(),
     ) {
       this.webhookDestinationPort = port
       this.webhookPath = webhookPath
-      this.webhookSecret = webhookSecret
       this.clientSecrets = clientSecrets
 
       webhookPostRequest =
@@ -143,7 +139,7 @@ class AcceptanceTestExtension(
     }
 
     @OptIn(ExperimentalStdlibApi::class)
-    private fun sign(body: String, secret: WebhookOptions.Secret = webhookSecret): Header {
+    private fun sign(body: String, secret: WebhookOptions.Secret): Header {
       return Header(
           "X-Hub-Signature-256",
           "sha256=" +
@@ -152,29 +148,7 @@ class AcceptanceTestExtension(
       )
     }
 
-    fun sendWebhook(payload: WebhookPayload) {
-      log.info { "Sending webhook $payload ..." }
-
-      val body = payload.asJson()
-
-      RestAssured.given(webhookPostRequest)
-          .body(body)
-          .header(sign(body))
-          .header("X-GitHub-Event", payload.type)
-          .log()
-          .method()
-          .log()
-          .uri()
-          .log()
-          .headers()
-          .post(webhookPath)
-          .then()
-          .statusCode(200)
-          .log()
-          .ifError()
-    }
-
-    fun sendWebhookWithClientId(payload: WebhookPayload, clientId: String) {
+    fun sendWebhook(payload: WebhookPayload, clientId: String) {
       val secret =
           clientSecrets[clientId]
               ?: throw IllegalArgumentException("No secret configured for client '$clientId'")

--- a/src/test/kotlin/test/util/TestConstants.kt
+++ b/src/test/kotlin/test/util/TestConstants.kt
@@ -1,0 +1,6 @@
+package test.util
+
+object TestConstants {
+  const val TEST_CLIENT_ID = "test-org"
+  const val TEST_CLIENT_SECRET = "test-client-secret"
+}


### PR DESCRIPTION
All GitHub webhooks are migrated to the  per-client /webhook/{clientId} endpoints introduced in #67 and verified ok. This removes the now-dead shared-secret code path:

- Drop /webhook route and webhook.secret property parsing
- Drop convenience constructor on WebhookSecretValidatorFilter
- Rename test helper sendWebhookWithClientId -> sendWebhook (single method now); callers updated to pass a clientId
- Flatten WebhookSecretValidatorFilterTest now that there is one path
- Extract TEST_CLIENT_ID / TEST_CLIENT_SECRET to a shared TestConstants
- Rewrite webhooks-and-secrets.md with per-client as the only flow